### PR TITLE
Fixed fixrtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,15 +1,13 @@
 import pytest
-from playwright.sync_api import sync_playwright
-
-@pytest.fixture(scope='session')
-def browser():
-    with sync_playwright() as p:
-        browser = p.chromium.launch(headless=False)
-        yield browser
-        browser.close()
+from playwright.sync_api import sync_playwright, Page
+from pages.orangehrm_home_page import HomePage
+from pages.orangehrm_login_page import LoginPage
 
 @pytest.fixture
-def page(browser):
-    page = browser.new_page()
-    yield page
-    page.close()
+def login_page(page: Page) -> LoginPage:
+    return LoginPage(page)
+
+@pytest.fixture
+def home_page(page: Page) -> HomePage:
+    return HomePage(page)
+

--- a/pages/orangehrm_home_page.py
+++ b/pages/orangehrm_home_page.py
@@ -1,4 +1,4 @@
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Page
 
 class HomePage:
 

--- a/pages/orangehrm_login_page.py
+++ b/pages/orangehrm_login_page.py
@@ -9,6 +9,9 @@ class LoginPage:
         self.password_input = page.get_by_role("textbox", name="Password")
         self.login_button = page.get_by_role("button", name="Login")
 
+    def goto(self):
+        self.page.goto("https://opensource-demo.orangehrmlive.com/web/index.php/auth/login")
+
     def enter_username(self, username: str):
         self.username_input.fill(username)
 

--- a/tests/test_login_orangehrm.py
+++ b/tests/test_login_orangehrm.py
@@ -1,15 +1,14 @@
-import time
-from turtle import isvisible
 from playwright.sync_api import Page, expect
+
 from pages.orangehrm_home_page import HomePage
 from pages.orangehrm_login_page import LoginPage
 
-def test_example(page: Page) -> None:
-    login_page = LoginPage(page)
-    home_page = HomePage(page)
 
-    page.goto("https://opensource-demo.orangehrmlive.com/web/index.php/auth/login")
+def test_example(login_page: LoginPage, home_page: HomePage):
 
+
+    login_page.goto()
+  
     login_page.login('Admin', 'admin123')
     
     expect(home_page.upgrade_button).to_be_visible()


### PR DESCRIPTION
In order to get Trace Viewer working with the OrangeHRM test, I had to remove generic Browser and Page fixtures and replace with fixtures from the Page Objects. I believe the redundant elements might have been kicking off too many instances of pages "confusing" Trace Viewer. We'll see if there is a better way to do this.