### PR TITLE
Fix for improved tracing options

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,13 +1,22 @@
 import pytest
-from playwright.sync_api import sync_playwright, Page
-from pages.orangehrm_home_page import HomePage
-from pages.orangehrm_login_page import LoginPage
 
-@pytest.fixture
-def login_page(page: Page) -> LoginPage:
-    return LoginPage(page)
+def pytest_addoption(parser):
+    parser.addoption(
+        "--enable-trace",
+        action="store_true",
+        default=False,
+        help="Enable Playwright tracing for tests",
+    )
 
-@pytest.fixture
-def home_page(page: Page) -> HomePage:
-    return HomePage(page)
+@pytest.fixture(autouse=True)
+def trace_setup(context, request):
+    # Check if tracing is enabled via CLI
+    if not request.config.getoption("--enable-trace"):
+        yield  # do nothing
+        return
+
+    # Start tracing if enabled
+    context.tracing.start(screenshots=True, snapshots=True, sources=True)
+    yield
+    context.tracing.stop(path=f"trace_{request.node.name}.zip")
 

--- a/tests/test_login_orangehrm.py
+++ b/tests/test_login_orangehrm.py
@@ -4,8 +4,9 @@ from pages.orangehrm_home_page import HomePage
 from pages.orangehrm_login_page import LoginPage
 
 
-def test_example(login_page: LoginPage, home_page: HomePage):
-
+def test_example(page: Page):
+    login_page = LoginPage(page)
+    home_page = HomePage(page)
 
     login_page.goto()
   


### PR DESCRIPTION
We remove explicit Page and Browser fixtures from conftest.py and let built-in Pytest capabilities handle them. We also removed Page Objects from fixtures. We added code to conftest.py for enhanced tracing of all test with a custom runtime flag. Now there is an option to run a trace of a single test with --tracing=on or to run traces for all test with zip files sent to the root directory of the project with --enable-trace. Group effort courtesy of Raghav, ChatGPT and me.