### PR TITLE
Restored Page Objects as Fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,7 @@
 import pytest
+from playwright.sync_api import Page
+from pages.orangehrm_home_page import HomePage
+from pages.orangehrm_login_page import LoginPage
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -19,4 +22,12 @@ def trace_setup(context, request):
     context.tracing.start(screenshots=True, snapshots=True, sources=True)
     yield
     context.tracing.stop(path=f"trace_{request.node.name}.zip")
+
+@pytest.fixture
+def login_page(page: Page):
+    return LoginPage(page)
+
+@pytest.fixture
+def home_page(page: Page):
+    return HomePage(page)
 

--- a/tests/test_login_orangehrm.py
+++ b/tests/test_login_orangehrm.py
@@ -1,20 +1,16 @@
-from playwright.sync_api import Page, expect
+from playwright.sync_api import expect
 
 from pages.orangehrm_home_page import HomePage
 from pages.orangehrm_login_page import LoginPage
 
 
-def test_example(page: Page):
-    login_page = LoginPage(page)
-    home_page = HomePage(page)
+def test_example(login_page: LoginPage, home_page: HomePage):
 
     login_page.goto()
-  
-    login_page.login('Admin', 'admin123')
-    
+
+    login_page.login("Admin", "admin123")
+
     expect(home_page.upgrade_button).to_be_visible()
 
     home_page.click_performance()
     home_page.click_dashboard()
-
-


### PR DESCRIPTION
According to best practices on the Playwright documentation, page objects should be fixtures; et voila!